### PR TITLE
fix(): Fix tsconfig detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webpack-typescript-config-dump-plugin",
   "description": "A webpack plugin to cache compiled typescript config on the file system",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "Sergey Nikitin <srg.post@gmail.com>",
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,13 +70,13 @@ export class TypescriptConfigDumpPlugin {
     const configFile = get(
       this.loader,
       ["options", "configFile"],
-      "./tsconfig.json"
+      "../../../tsconfig.json"
     );
-    const compilerOptions = get(this.loader, ["options", "compilerOptions"]);
-
-    if (!compilerOptions) {
-      return;
-    }
+    const compilerOptions = get(
+      this.loader,
+      ["options", "compilerOptions"],
+      {}
+    );
 
     let repoConfig;
     try {


### PR DESCRIPTION
We could not find tsconfig if there is no loader parameters specified.
In this commit we attempt to fix this behavior and allow
to dump tsconfig file without having to specify the options